### PR TITLE
Upgrade Mybatis-Migration support to 3.3.7 to work around an error in…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
 		<spring-boot.version>2.1.0.RELEASE</spring-boot.version>
-		<mybatis-migrations.version>3.3.1</mybatis-migrations.version>
+		<mybatis-migrations.version>3.3.7</mybatis-migrations.version>
 		<jcommander.version>1.69</jcommander.version>
 	</properties>
 

--- a/src/main/java/de/bessonov/mybatis/migrations/SpringMigrationLoader.java
+++ b/src/main/java/de/bessonov/mybatis/migrations/SpringMigrationLoader.java
@@ -1,7 +1,6 @@
 package de.bessonov.mybatis.migrations;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.Reader;
 import java.math.BigDecimal;
 import java.util.Collection;
@@ -9,7 +8,6 @@ import java.util.List;
 import java.util.Properties;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
-
 import org.apache.ibatis.migration.Change;
 import org.apache.ibatis.migration.MigrationException;
 import org.apache.ibatis.migration.MigrationLoader;
@@ -111,9 +109,11 @@ public class SpringMigrationLoader implements MigrationLoader {
 
 	protected Reader getReader(String fileName, boolean undo) {
 		try {
-			try (InputStream file = getResource(fileName).getURL().openStream()) {
-				return new MigrationReader(file, charset, undo, properties);
+			Resource scriptResource = getResource(fileName);
+			if (scriptResource.exists()) {
+				return new MigrationReader(scriptResource.getInputStream(), charset, undo, properties);
 			}
+			return null;
 		} catch (IOException e) {
 			throw new MigrationException("Error reading " + fileName, e);
 		}


### PR DESCRIPTION
Upgrade Mybatis-Migration support to 3.3.7 to work around an error introduced by https://github.com/mybatis/migrations/commit/a5d8a725befc54483a93fba14a82f99b1a176122#diff-2c0b0afa4090a13167224923f2536046. Also by checking if the script file exists before creating a MigrationReader, code now handles case when onabort.sql isn't found.